### PR TITLE
A basic html/css only dark mode

### DIFF
--- a/static/vimhelp.css
+++ b/static/vimhelp.css
@@ -1,6 +1,10 @@
 *, ::before, ::after { box-sizing: border-box; }
 
-html { line-height: 1.15; font-family: georgia, palatino, serif; }
+html { line-height: 1.15; font-family: georgia, palatino, serif; background-color: #FFF; color: #000; }
+
+@media(prefers-color-scheme: dark) {
+  html { line-height: 1.15; font-family: georgia, palatino, serif; background-color: #000; color: #FFF; }
+}
 
 /* top bar: quick links with search box */
 .bar { margin-bottom: 2em; display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 0.5em; }
@@ -100,3 +104,20 @@ a.l:active, a.l:hover { color: rgb(0, 200, 200); }
 
 /* external url */
 .u { color: rgb(250, 0, 250); }
+
+@media(prefers-color-scheme: dark) {
+  /* hidden links */
+  a.d { color: #FFF; }
+  a.d:link, a.d:visited { text-decoration: underline silver; }
+  a.d:active, a.d:hover { text-decoration: underline black; }
+
+  /* note */
+  .n { color: yellow; background-color: blue; }
+
+  .select2-container--default .select2-selection--single {
+    background-color: rgb(59, 59, 59) !important;
+  }
+  .select2-dropdown {
+    background-color: rgb(59, 59, 59) !important;
+  }
+}

--- a/vimhelp/vimh2h.py
+++ b/vimhelp/vimh2h.py
@@ -11,6 +11,7 @@ HEAD_FMT = """\
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+<meta name="color-scheme" content="light dark">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="{project.name} help pages, always up-to-date">
 <title>{project.name}: {filename}</title>


### PR DESCRIPTION
I'm not the most frequent user of dark mode, but sometimes it's nice to have.

So I make a very basic dark mode, no JavaScript involved. Older browsers will ignore the dark mode and show the pages as usual. More modern browsers will use dark mode if the user has activated it in preferences.

Since the select2-dropdown doesn't seem to have a dark mode theme, I created a very simple css patch for it.
![image](https://user-images.githubusercontent.com/9462004/206838429-e64189a2-9f4e-4199-ae1b-f5d6b6da27bb.png)
