### PR TITLE
Fix concealed text tab alignment bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,21 @@
 This is the code behind the https://vimhelp.org website. It runs on
 [Google App Engine](https://cloud.google.com/appengine/).
 
+## Running on Google App Engine
+
 To make testing and deploying easier, a `tasks.py` file exists for use
 with the [Invoke](https://www.pyinvoke.org/) tool.
+
+## Generating static site
+
+To generate a static site instead of running on Google App Engine, run the
+following (replace the `-i` parameter with the Vim documentation location on
+your computer):
+
+    python3 -m venv --upgrade-deps .venv
+    .venv/bin/pip install -r requirements.txt
+    scripts/h2h.py -i /usr/share/vim/vim90/doc/ -o html/
+
+## License
 
 This code is made freely available under the MIT License (see file LICENSE).

--- a/README.md
+++ b/README.md
@@ -3,20 +3,26 @@
 This is the code behind the https://vimhelp.org website. It runs on
 [Google App Engine](https://cloud.google.com/appengine/).
 
-## Running on Google App Engine
-
 To make testing and deploying easier, a `tasks.py` file exists for use
-with the [Invoke](https://www.pyinvoke.org/) tool.
+with the [_Invoke_](https://www.pyinvoke.org/) tool (which is similar in
+spirit to _Make_).
 
-## Generating static site
+## Generating static pages
 
-To generate a static site instead of running on Google App Engine, run the
-following (replace the `-i` parameter with the Vim documentation location on
-your computer):
+To generate static HTML pages instead of running on Google App Engine:
 
-    python3 -m venv --upgrade-deps .venv
-    .venv/bin/pip install -r requirements.txt
-    scripts/h2h.py -i /usr/share/vim/vim90/doc/ -o html/
+- Create a virtualenv. If you have _Invoke_ installed, this is as easy as
+  `inv venv`. Alternatively:
+  ```
+  python3 -m venv --upgrade-deps .venv
+  .venv/bin/pip install -r requirements.txt
+  ```
+- Run the following (replace the `-i` parameter with the Vim documentation
+  location on your computer):
+  ```
+  scripts/h2h.py -i /usr/share/vim/vim90/doc/ -o html/
+  ```
+  The script offers a few options; run with `-h` to see what is available.
 
 ## License
 

--- a/vimhelp/vimh2h.py
+++ b/vimhelp/vimh2h.py
@@ -31,7 +31,7 @@ NeovimProject.other = VimProject
 
 PROJECTS = {"vim": VimProject, "neovim": NeovimProject}
 
-FAQ_LINE = '<a href="vim_faq.txt.html#vim_faq.txt" class="l">vim_faq.txt</a>   Frequently Asked Questions\n'
+FAQ_LINE = '<a href="vim_faq.txt.html#vim_faq.txt" class="l">vim_faq.txt</a>\tFrequently Asked Questions\n'
 
 RE_TAGLINE = re.compile(r"(\S+)\s+(\S+)")
 
@@ -41,7 +41,7 @@ PAT_HEADER = r"(^.*~$)"
 PAT_GRAPHIC = r"(^.* `$)"
 PAT_PIPEWORD = r"(?<!\\)\|([#-)!+-{}~]+)\|"
 PAT_STARWORD = r"\*([#-)!+-~]+)\*(?:(?=\s)|$)"
-PAT_COMMAND = r"`([^` ]+)`"
+PAT_COMMAND = r"`([^` \t]+)`"
 PAT_OPTWORD = r"('(?:[a-z]{2,}|t_..)')"
 PAT_CTRL = r"((?:CTRL(?:-SHIFT)?|META|ALT)-(?:W_)?(?:\{char\}|<[A-Za-z]+?>|.)?)"
 PAT_SPECIAL = (
@@ -80,9 +80,9 @@ RE_NEWLINE = re.compile(r"[\r\n]")
 RE_HRULE = re.compile(r"(?:===.*===|---.*---)$")
 RE_HRULE1 = re.compile(r"===.*===$")
 RE_HEADING = re.compile(
-    r"[0-9. *]*"
-    r"(?! *vim:| *Next chapter:| *Copyright: | *Table of contents:| *Advance information about|$)"
-    r"(.+?) *(?:\*|~?$)"
+    r"[0-9.\s*]*"
+    r"(?!\s*vim:|\s*Next chapter:|\s*Copyright:|\s*Table of contents:|\s*Advance information about|$)"
+    r"(.+?)\s*(?:\*|~?$)"
 )
 RE_EG_START = re.compile(r"(?:.* )?>$")
 RE_EG_END = re.compile(r"[^ \t]")


### PR DESCRIPTION
Vim docs use concealed texts for a few types of texts: tag links (e.g. `|:edit|`), code blocks (e.g. `` `some code` ``), and tags (e.g. `*some_tag*`). The begin/end characters are hidden from view for convenience, but when Vim is calculating tab-width calculation, the concealed characters *do* count towards the tab.

The way vimhelp worked is that it first called `line.expandtabs()` to convert the hard tabs to spaces, before removing the concealed characters. Because of that, the alignment is no longer correct unless you add back the characters in as whitespace. This is somewhat difficult to do because concealed characters followed by a normal space do *not* need to be filled back in. You only want to do that when it's followed by a tab.

To fix this, just do not called `expandtabs()` and instead use hard tabs. This is fine because HTML/CSS uses 8 chars for tabs by default. We detect the case where a concealed tag is followed by a hard tab ("\t") and then manually inject two empty space after it. This fixes all the alignment issues.

This is similar to the fix at Neovim's doc generation tool which had a similar bug: https://github.com/neovim/neovim/pull/20690

Also, as a drive-by, add README documentation for how to generate a static site. Feel free to omit that if you would like to author it differently.