### PR TITLE
Update README to reflect using uv instead of requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ To generate static HTML pages instead of running on Google App Engine:
 - Create a virtualenv. If you have _Invoke_ installed, this is as easy as
   `inv venv`. Alternatively:
   ```
-  python3 -m venv --upgrade-deps .venv
-  .venv/bin/pip install -r requirements.txt
+  uv sync
   ```
 - Run the following (replace the `-i` parameter with the Vim documentation
   location on your computer):


### PR DESCRIPTION
Commit 1a062171 removed requirements.txt so the instructions were no longer correct. Update instructions to use uv instead.